### PR TITLE
centos7.sh: fix move tar.gz to ~/tar

### DIFF
--- a/centos7.sh
+++ b/centos7.sh
@@ -121,6 +121,6 @@ tar czf $NAME-$VERSION-$PKG_VERSION.tar.gz \
 # Move tar.gz to ~/tar
 ################################################################################
 
-mkdir ~/tar
-cp $NAME-$VERSION-$PKG_VERSION.tar.gz ~/tar
+mkdir -p ~/tar
+cp -f $NAME-$VERSION-$PKG_VERSION.tar.gz ~/tar
 


### PR DESCRIPTION
do not fail if ~/tar exists
force copy to ~/tar