### PR TITLE
fix CentOS7 packaging for current master

### DIFF
--- a/templates/centos7/centos7.spec.tpl
+++ b/templates/centos7/centos7.spec.tpl
@@ -499,6 +499,8 @@ EOF
 /usr/lib/one/ruby/cloud/CloudServer.rb
 /usr/lib/one/ruby/cloud/CloudAuth/*
 
+/usr/lib/one/ruby/opennebula_driver.rb
+
 %{_datadir}/one/install_gems
 %{_datadir}/one/Gemfile
 %{_datadir}/one/Gemfile.lock


### PR DESCRIPTION
error: Installed (but unpackaged) file(s) found:
   /usr/lib/one/ruby/opennebula_driver.rb

Probably should be ported to other distro packaging templates too...