### PR TITLE
F #1684: Added LXD extra configuration for 1810

### DIFF
--- a/templates/ubuntu1810-debian/opennebula-node-lxd.postinst
+++ b/templates/ubuntu1810-debian/opennebula-node-lxd.postinst
@@ -23,6 +23,9 @@ profiles:
        limits.cpu: "1"
        limits.cpu.allowance: 50%
        limits.memory: 512MB
+       security.idmap.base: "100000"
+       security.idmap.isolated: "true"
+       security.idmap.size: "65536"
     devices:
       root:
         path: /


### PR DESCRIPTION
snap packages don't read uid and guid configruation from `/etc/subgid /etc/subuid`, since we create containers from scratch, the filesystem doesn't get remapped and our images generated on 18.04 start from a hostid from which to map = `100000`, but snaps starts mapping from `1000000`