### PR TITLE
F #70 Fix required full snap lxc

### DIFF
--- a/templates/ubuntu1810-debian/opennebula-node-lxd.postinst
+++ b/templates/ubuntu1810-debian/opennebula-node-lxd.postinst
@@ -19,6 +19,7 @@ if [ "$1" = "configure" ]; then
 
         if ! grep -qF '/snap/bin/lxc' /etc/sudoers.d/opennebula-lxd; then
             echo 'oneadmin ALL=(ALL:ALL) NOPASSWD: /snap/bin/lxc' >> /etc/sudoers.d/opennebula-lxd
+            echo 'Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/snap/bin' >> /etc/sudoers.d/opennebula-lxd
         fi
     fi
 

--- a/templates/ubuntu1904-debian/opennebula-node-lxd.postinst
+++ b/templates/ubuntu1904-debian/opennebula-node-lxd.postinst
@@ -19,6 +19,7 @@ if [ "$1" = "configure" ]; then
 
         if ! grep -qF '/snap/bin/lxc' /etc/sudoers.d/opennebula-lxd; then
             echo 'oneadmin ALL=(ALL:ALL) NOPASSWD: /snap/bin/lxc' >> /etc/sudoers.d/opennebula-lxd
+            echo 'Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/snap/bin' >> /etc/sudoers.d/opennebula-lxd
         fi
     fi
 


### PR DESCRIPTION
There were silent errors

![image](https://user-images.githubusercontent.com/16429804/57429552-26e3d300-71f2-11e9-891c-48716f58cd02.png)

also the nic hotplug which runs recontextualization inside the container failed.


`/snap/bin` isn't under oneadmin secure_path and code prefixes lxc with plain sudo

I couldn't find a way to extend the secure path already written in the opennebula file sudoers.

Is either this idea or prefixing the full `/snap/bin/lxc` like [tests do](https://github.com/dann1/development/blob/ba3b94933b6d1cd179e27ca6434b4a8ef98073dd/readiness/spec/lib_lxd/lxd.rb#L15)

Merge this or https://github.com/OpenNebula/one/pull/3322