### PR TITLE
M #: Update sunstone prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ cd src/sunstone/public
 npm install -g bower grunt grunt-cli
 npm install
 bower install --allow-root --config.interactive=false
+cd bower_components/no-vnc/ && npm install && ./utils/use_require.js --clean --as amd && sed -i -e "s/'\.\//'\.\.\/bower_components\/no-vnc\/lib\//g" lib/rfb.js
 grunt sass
 grunt requirejs
 rm -rf node_modules/


### PR DESCRIPTION
Build fails when running `grunt requirejs` if that is not run previously. 

```
[root@infra-client man]# cd ../../src/sunstone/public/
[root@infra-client public]# npm install -g bower grunt grunt-cli
npm WARN deprecated bower@1.8.8: We don't recommend using Bower for new projects. Please consider Yarn and Webpack or Parcel. You can read how to migrate legacy project here: https://bower.io/blog/2017/how-to-migrate-away-from-bower/
/usr/bin/bower -> /usr/lib/node_modules/bower/bin/bower
/usr/bin/grunt -> /usr/lib/node_modules/grunt/bin/grunt
/usr/bin/grunt -> /usr/lib/node_modules/grunt-cli/bin/grunt
/usr/lib
├── bower@1.8.8 
├── grunt@1.0.4 
└── grunt-cli@1.3.2 

[root@infra-client public]# npm install -g bower grunt grunt-cli^C
[root@infra-client public]# npm install
npm WARN opennebula-sunstone@0.0.1 No repository field.
npm WARN opennebula-sunstone@0.0.1 No license field.
[root@infra-client public]# bower install --allow-root --config.interactive=false
[root@infra-client public]# grunt sass
Running "sass:dist" (sass) task

Done.
[root@infra-client public]# grunt requirejs
Running "requirejs:compileCSS" (requirejs) task

Running "requirejs:compileJS" (requirejs) task
{ Error: Error: ENOTEMPTY: directory not empty, rmdir '/root/infra/dev/opennebula-5.9.80/src/sunstone/public/dist/'
  at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28332:19
  at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3059:39
  at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2999:25
  at Function.prim.nextTick (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28083:9)
  at Object.errback (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2998:26)
  at Object.callback (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2984:23)
  at Object.then (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3038:23)
  at build (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28289:12)
  at runBuild (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:30302:17)
  at Object.execCb (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1946:33)
  at Object.check (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1133:51)
  at Object.enable (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1426:22)
  at Object.init (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1038:26)
  at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1710:36
  at _combinedTickCallback (internal/process/next_tick.js:73:7)
  at process._tickCallback (internal/process/next_tick.js:104:9)

  originalError: 
   { Error: ENOTEMPTY: directory not empty, rmdir '/root/infra/dev/opennebula-5.9.80/src/sunstone/public/dist/'
     at Error (native)
     at Object.fs.rmdirSync (fs.js:896:18)
     at Object.deleteFile (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3714:24)
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28364:22
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3041:37
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2989:25
     at Function.prim.nextTick (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28083:9)
     at Object.callback (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2988:26)
     at Object.then (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3038:23)
     at Object.start (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3031:34)
     at Function.build._run (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28349:23)
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28288:26
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3041:37
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2989:25
     at Function.prim.nextTick (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28083:9)
     at Object.callback (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:2988:26)
     at Object.then (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3038:23)
     at Object.start (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:3031:34)
     at build (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:28265:23)
     at runBuild (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:30302:17)
     at Object.execCb (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1946:33)
     at Object.check (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1133:51)
     at Object.enable (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1426:22)
     at Object.init (/root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1038:26)
     at /root/infra/dev/opennebula-5.9.80/src/sunstone/public/node_modules/requirejs/bin/r.js:1710:36
     at _combinedTickCallback (internal/process/next_tick.js:73:7)
     at process._tickCallback (internal/process/next_tick.js:104:9)
   
     errno: -39,
     code: 'ENOTEMPTY',
     syscall: 'rmdir',
     path: '/root/infra/dev/opennebula-5.9.80/src/sunstone/public/dist/' } }
```