### PR TITLE
B #68: Datastores directories contained in the package

### DIFF
--- a/templates/debian10/opennebula-flow.postrm
+++ b/templates/debian10/opennebula-flow.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/oneflow.log*
+fi
+
+#DEBHELPER#

--- a/templates/debian10/opennebula-gate.postrm
+++ b/templates/debian10/opennebula-gate.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/onegate.log*
+fi
+
+#DEBHELPER#

--- a/templates/debian10/opennebula-sunstone.postrm
+++ b/templates/debian10/opennebula-sunstone.postrm
@@ -1,2 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/sunstone.log* \
+        /var/log/one/sunstone.error* \
+        /var/log/one/novnc.log* \
+        /var/log/one/econe-server.log*
+fi
+
 dpkg-maintscript-helper mv_conffile /etc/one/sunstone-views/vcenter.yaml /etc/one/sunstone-views/admin_vcenter.yaml 4.10.2-1 -- "$@"
 
+#DEBHELPER#

--- a/templates/debian10/opennebula.dirs
+++ b/templates/debian10/opennebula.dirs
@@ -1,4 +1,5 @@
 /var/log/one/
 /var/lib/one/
+/var/lib/one/datastores/
 /var/lib/one/.one
 /etc/one/auth/certificates/

--- a/templates/debian10/opennebula.install
+++ b/templates/debian10/opennebula.install
@@ -1,4 +1,5 @@
-dist/var/lib/one/datastores/*    /var/lib/one/datastores
+### See https://github.com/OpenNebula/packages/issues/68
+#dist/var/lib/one/datastores/*                /var/lib/one/datastores
 dist/var/lib/one/remotes/etc/*                /var/lib/one/remotes/etc/
 dist/var/lib/one/remotes/auth/*               /var/lib/one/remotes/auth/
 dist/var/lib/one/remotes/datastore/*          /var/lib/one/remotes/datastore/

--- a/templates/debian10/opennebula.postinst
+++ b/templates/debian10/opennebula.postinst
@@ -11,8 +11,6 @@ if [ "$1" = "configure" ]; then
     chown $ONE_USER:$ONE_GROUP      /var/lib/one
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/vms
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/0
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/1
     chown -R $ONE_USER:$ONE_GROUP   /var/lib/one/remotes
 
     if [ ! -f $ONEAUTH ]; then

--- a/templates/debian10/opennebula.postrm
+++ b/templates/debian10/opennebula.postrm
@@ -2,13 +2,29 @@
 
 set -e
 
-ONEHOME=/var/lib/one
-ONE_GROUP=oneadmin
-ONE_USER=oneadmin
-
-if [ "$1" = "remove" ]; then
+if [ "$1" = 'purge' ]; then
     # Remove logs
-    rm -rf /var/log/one/*
+    rm -rf /var/log/one/oned.log* \
+        /var/log/one/sched.log* \
+        /var/log/one/[[:digit:]]*.log
+
+    # Remove vms directory
+    rm -rf /var/lib/one/vms
+
+    # Remove empty datastore directories
+    for DIR in /var/lib/one/datastores/*   \
+               /var/lib/one/datastores/.*  \
+               /var/lib/one/datastores; do
+        # ignore . and ..
+        BASE_DIR=$(basename "${DIR}")
+        if [ "${BASE_DIR}" = '.' ] || [ "${BASE_DIR}" = '..' ]; then
+            continue
+        fi
+
+        if [ -d "${DIR}" ]; then
+            rmdir --ignore-fail-on-non-empty "${DIR}" 2>/dev/null || :
+        fi
+    done
 fi
 
 #DEBHELPER#

--- a/templates/debian9/opennebula-flow.postrm
+++ b/templates/debian9/opennebula-flow.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/oneflow.log*
+fi
+
+#DEBHELPER#

--- a/templates/debian9/opennebula-gate.postrm
+++ b/templates/debian9/opennebula-gate.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/onegate.log*
+fi
+
+#DEBHELPER#

--- a/templates/debian9/opennebula-sunstone.postrm
+++ b/templates/debian9/opennebula-sunstone.postrm
@@ -1,2 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/sunstone.log* \
+        /var/log/one/sunstone.error* \
+        /var/log/one/novnc.log* \
+        /var/log/one/econe-server.log*
+fi
+
 dpkg-maintscript-helper mv_conffile /etc/one/sunstone-views/vcenter.yaml /etc/one/sunstone-views/admin_vcenter.yaml 4.10.2-1 -- "$@"
 
+#DEBHELPER#

--- a/templates/debian9/opennebula.dirs
+++ b/templates/debian9/opennebula.dirs
@@ -1,4 +1,5 @@
 /var/log/one/
 /var/lib/one/
+/var/lib/one/datastores/
 /var/lib/one/.one
 /etc/one/auth/certificates/

--- a/templates/debian9/opennebula.install
+++ b/templates/debian9/opennebula.install
@@ -1,4 +1,5 @@
-dist/var/lib/one/datastores/*    /var/lib/one/datastores
+### See https://github.com/OpenNebula/packages/issues/68
+#dist/var/lib/one/datastores/*                /var/lib/one/datastores
 dist/var/lib/one/remotes/etc/*                /var/lib/one/remotes/etc/
 dist/var/lib/one/remotes/auth/*               /var/lib/one/remotes/auth/
 dist/var/lib/one/remotes/datastore/*          /var/lib/one/remotes/datastore/

--- a/templates/debian9/opennebula.postinst
+++ b/templates/debian9/opennebula.postinst
@@ -11,8 +11,6 @@ if [ "$1" = "configure" ]; then
     chown $ONE_USER:$ONE_GROUP      /var/lib/one
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/vms
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/0
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/1
     chown -R $ONE_USER:$ONE_GROUP   /var/lib/one/remotes
 
     if [ ! -f $ONEAUTH ]; then

--- a/templates/debian9/opennebula.postrm
+++ b/templates/debian9/opennebula.postrm
@@ -2,13 +2,29 @@
 
 set -e
 
-ONEHOME=/var/lib/one
-ONE_GROUP=oneadmin
-ONE_USER=oneadmin
-
-if [ "$1" = "remove" ]; then
+if [ "$1" = 'purge' ]; then
     # Remove logs
-    rm -rf /var/log/one/*
+    rm -rf /var/log/one/oned.log* \
+        /var/log/one/sched.log* \
+        /var/log/one/[[:digit:]]*.log
+
+    # Remove vms directory
+    rm -rf /var/lib/one/vms
+
+    # Remove empty datastore directories
+    for DIR in /var/lib/one/datastores/*   \
+               /var/lib/one/datastores/.*  \
+               /var/lib/one/datastores; do
+        # ignore . and ..
+        BASE_DIR=$(basename "${DIR}")
+        if [ "${BASE_DIR}" = '.' ] || [ "${BASE_DIR}" = '..' ]; then
+            continue
+        fi
+
+        if [ -d "${DIR}" ]; then
+            rmdir --ignore-fail-on-non-empty "${DIR}" 2>/dev/null || :
+        fi
+    done
 fi
 
 #DEBHELPER#

--- a/templates/ubuntu1604/opennebula-flow.postrm
+++ b/templates/ubuntu1604/opennebula-flow.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/oneflow.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1604/opennebula-gate.postrm
+++ b/templates/ubuntu1604/opennebula-gate.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/onegate.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1604/opennebula-sunstone.postrm
+++ b/templates/ubuntu1604/opennebula-sunstone.postrm
@@ -1,2 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/sunstone.log* \
+        /var/log/one/sunstone.error* \
+        /var/log/one/novnc.log* \
+        /var/log/one/econe-server.log*
+fi
+
 dpkg-maintscript-helper mv_conffile /etc/one/sunstone-views/vcenter.yaml /etc/one/sunstone-views/admin_vcenter.yaml 4.10.2-1 -- "$@"
 
+#DEBHELPER#

--- a/templates/ubuntu1604/opennebula.dirs
+++ b/templates/ubuntu1604/opennebula.dirs
@@ -1,4 +1,5 @@
 /var/log/one/
 /var/lib/one/
+/var/lib/one/datastores/
 /var/lib/one/.one
 /etc/one/auth/certificates/

--- a/templates/ubuntu1604/opennebula.install
+++ b/templates/ubuntu1604/opennebula.install
@@ -1,4 +1,5 @@
-dist/var/lib/one/datastores/*    /var/lib/one/datastores
+### See https://github.com/OpenNebula/packages/issues/68
+#dist/var/lib/one/datastores/*                /var/lib/one/datastores
 dist/var/lib/one/remotes/etc/*                /var/lib/one/remotes/etc/
 dist/var/lib/one/remotes/auth/*               /var/lib/one/remotes/auth/
 dist/var/lib/one/remotes/datastore/*          /var/lib/one/remotes/datastore/

--- a/templates/ubuntu1604/opennebula.postinst
+++ b/templates/ubuntu1604/opennebula.postinst
@@ -11,8 +11,6 @@ if [ "$1" = "configure" ]; then
     chown $ONE_USER:$ONE_GROUP      /var/lib/one
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/vms
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/0
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/1
     chown -R $ONE_USER:$ONE_GROUP   /var/lib/one/remotes
 
     if [ ! -f $ONEAUTH ]; then

--- a/templates/ubuntu1604/opennebula.postrm
+++ b/templates/ubuntu1604/opennebula.postrm
@@ -2,13 +2,29 @@
 
 set -e
 
-ONEHOME=/var/lib/one
-ONE_GROUP=oneadmin
-ONE_USER=oneadmin
-
-if [ "$1" = "remove" ]; then
+if [ "$1" = 'purge' ]; then
     # Remove logs
-    rm -rf /var/log/one/*
+    rm -rf /var/log/one/oned.log* \
+        /var/log/one/sched.log* \
+        /var/log/one/[[:digit:]]*.log
+
+    # Remove vms directory
+    rm -rf /var/lib/one/vms
+
+    # Remove empty datastore directories
+    for DIR in /var/lib/one/datastores/*   \
+               /var/lib/one/datastores/.*  \
+               /var/lib/one/datastores; do
+        # ignore . and ..
+        BASE_DIR=$(basename "${DIR}")
+        if [ "${BASE_DIR}" = '.' ] || [ "${BASE_DIR}" = '..' ]; then
+            continue
+        fi
+
+        if [ -d "${DIR}" ]; then
+            rmdir --ignore-fail-on-non-empty "${DIR}" 2>/dev/null || :
+        fi
+    done
 fi
 
 #DEBHELPER#

--- a/templates/ubuntu1804/opennebula-flow.postrm
+++ b/templates/ubuntu1804/opennebula-flow.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/oneflow.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1804/opennebula-gate.postrm
+++ b/templates/ubuntu1804/opennebula-gate.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/onegate.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1804/opennebula-sunstone.postrm
+++ b/templates/ubuntu1804/opennebula-sunstone.postrm
@@ -1,2 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/sunstone.log* \
+        /var/log/one/sunstone.error* \
+        /var/log/one/novnc.log* \
+        /var/log/one/econe-server.log*
+fi
+
 dpkg-maintscript-helper mv_conffile /etc/one/sunstone-views/vcenter.yaml /etc/one/sunstone-views/admin_vcenter.yaml 4.10.2-1 -- "$@"
 
+#DEBHELPER#

--- a/templates/ubuntu1804/opennebula.dirs
+++ b/templates/ubuntu1804/opennebula.dirs
@@ -1,4 +1,5 @@
 /var/log/one/
 /var/lib/one/
+/var/lib/one/datastores/
 /var/lib/one/.one
 /etc/one/auth/certificates/

--- a/templates/ubuntu1804/opennebula.install
+++ b/templates/ubuntu1804/opennebula.install
@@ -1,4 +1,5 @@
-dist/var/lib/one/datastores/*    /var/lib/one/datastores
+### See https://github.com/OpenNebula/packages/issues/68
+#dist/var/lib/one/datastores/*                /var/lib/one/datastores
 dist/var/lib/one/remotes/etc/*                /var/lib/one/remotes/etc/
 dist/var/lib/one/remotes/auth/*               /var/lib/one/remotes/auth/
 dist/var/lib/one/remotes/datastore/*          /var/lib/one/remotes/datastore/

--- a/templates/ubuntu1804/opennebula.postinst
+++ b/templates/ubuntu1804/opennebula.postinst
@@ -11,8 +11,6 @@ if [ "$1" = "configure" ]; then
     chown $ONE_USER:$ONE_GROUP      /var/lib/one
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/vms
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/0
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/1
     chown -R $ONE_USER:$ONE_GROUP   /var/lib/one/remotes
 
     if [ ! -f $ONEAUTH ]; then

--- a/templates/ubuntu1804/opennebula.postrm
+++ b/templates/ubuntu1804/opennebula.postrm
@@ -2,13 +2,29 @@
 
 set -e
 
-ONEHOME=/var/lib/one
-ONE_GROUP=oneadmin
-ONE_USER=oneadmin
-
-if [ "$1" = "remove" ]; then
+if [ "$1" = 'purge' ]; then
     # Remove logs
-    rm -rf /var/log/one/*
+    rm -rf /var/log/one/oned.log* \
+        /var/log/one/sched.log* \
+        /var/log/one/[[:digit:]]*.log
+
+    # Remove vms directory
+    rm -rf /var/lib/one/vms
+
+    # Remove empty datastore directories
+    for DIR in /var/lib/one/datastores/*   \
+               /var/lib/one/datastores/.*  \
+               /var/lib/one/datastores; do
+        # ignore . and ..
+        BASE_DIR=$(basename "${DIR}")
+        if [ "${BASE_DIR}" = '.' ] || [ "${BASE_DIR}" = '..' ]; then
+            continue
+        fi
+
+        if [ -d "${DIR}" ]; then
+            rmdir --ignore-fail-on-non-empty "${DIR}" 2>/dev/null || :
+        fi
+    done
 fi
 
 #DEBHELPER#

--- a/templates/ubuntu1810/opennebula-flow.postrm
+++ b/templates/ubuntu1810/opennebula-flow.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/oneflow.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1810/opennebula-gate.postrm
+++ b/templates/ubuntu1810/opennebula-gate.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/onegate.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1810/opennebula-sunstone.postrm
+++ b/templates/ubuntu1810/opennebula-sunstone.postrm
@@ -1,2 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/sunstone.log* \
+        /var/log/one/sunstone.error* \
+        /var/log/one/novnc.log* \
+        /var/log/one/econe-server.log*
+fi
+
 dpkg-maintscript-helper mv_conffile /etc/one/sunstone-views/vcenter.yaml /etc/one/sunstone-views/admin_vcenter.yaml 4.10.2-1 -- "$@"
 
+#DEBHELPER#

--- a/templates/ubuntu1810/opennebula.dirs
+++ b/templates/ubuntu1810/opennebula.dirs
@@ -1,4 +1,5 @@
 /var/log/one/
 /var/lib/one/
+/var/lib/one/datastores/
 /var/lib/one/.one
 /etc/one/auth/certificates/

--- a/templates/ubuntu1810/opennebula.install
+++ b/templates/ubuntu1810/opennebula.install
@@ -1,4 +1,5 @@
-dist/var/lib/one/datastores/*    /var/lib/one/datastores
+### See https://github.com/OpenNebula/packages/issues/68
+#dist/var/lib/one/datastores/*                /var/lib/one/datastores
 dist/var/lib/one/remotes/etc/*                /var/lib/one/remotes/etc/
 dist/var/lib/one/remotes/auth/*               /var/lib/one/remotes/auth/
 dist/var/lib/one/remotes/datastore/*          /var/lib/one/remotes/datastore/

--- a/templates/ubuntu1810/opennebula.postinst
+++ b/templates/ubuntu1810/opennebula.postinst
@@ -11,8 +11,6 @@ if [ "$1" = "configure" ]; then
     chown $ONE_USER:$ONE_GROUP      /var/lib/one
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/vms
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/0
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/1
     chown -R $ONE_USER:$ONE_GROUP   /var/lib/one/remotes
 
     if [ ! -f $ONEAUTH ]; then

--- a/templates/ubuntu1810/opennebula.postrm
+++ b/templates/ubuntu1810/opennebula.postrm
@@ -2,13 +2,29 @@
 
 set -e
 
-ONEHOME=/var/lib/one
-ONE_GROUP=oneadmin
-ONE_USER=oneadmin
-
-if [ "$1" = "remove" ]; then
+if [ "$1" = 'purge' ]; then
     # Remove logs
-    rm -rf /var/log/one/*
+    rm -rf /var/log/one/oned.log* \
+        /var/log/one/sched.log* \
+        /var/log/one/[[:digit:]]*.log
+
+    # Remove vms directory
+    rm -rf /var/lib/one/vms
+
+    # Remove empty datastore directories
+    for DIR in /var/lib/one/datastores/*   \
+               /var/lib/one/datastores/.*  \
+               /var/lib/one/datastores; do
+        # ignore . and ..
+        BASE_DIR=$(basename "${DIR}")
+        if [ "${BASE_DIR}" = '.' ] || [ "${BASE_DIR}" = '..' ]; then
+            continue
+        fi
+
+        if [ -d "${DIR}" ]; then
+            rmdir --ignore-fail-on-non-empty "${DIR}" 2>/dev/null || :
+        fi
+    done
 fi
 
 #DEBHELPER#

--- a/templates/ubuntu1904/opennebula-flow.postrm
+++ b/templates/ubuntu1904/opennebula-flow.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/oneflow.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1904/opennebula-gate.postrm
+++ b/templates/ubuntu1904/opennebula-gate.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/onegate.log*
+fi
+
+#DEBHELPER#

--- a/templates/ubuntu1904/opennebula-sunstone.postrm
+++ b/templates/ubuntu1904/opennebula-sunstone.postrm
@@ -1,2 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = 'purge' ]; then
+    # Remove logs
+    rm -rf /var/log/one/sunstone.log* \
+        /var/log/one/sunstone.error* \
+        /var/log/one/novnc.log* \
+        /var/log/one/econe-server.log*
+fi
+
 dpkg-maintscript-helper mv_conffile /etc/one/sunstone-views/vcenter.yaml /etc/one/sunstone-views/admin_vcenter.yaml 4.10.2-1 -- "$@"
 
+#DEBHELPER#

--- a/templates/ubuntu1904/opennebula.dirs
+++ b/templates/ubuntu1904/opennebula.dirs
@@ -1,4 +1,5 @@
 /var/log/one/
 /var/lib/one/
+/var/lib/one/datastores/
 /var/lib/one/.one
 /etc/one/auth/certificates/

--- a/templates/ubuntu1904/opennebula.install
+++ b/templates/ubuntu1904/opennebula.install
@@ -1,4 +1,5 @@
-dist/var/lib/one/datastores/*    /var/lib/one/datastores
+### See https://github.com/OpenNebula/packages/issues/68
+#dist/var/lib/one/datastores/*                /var/lib/one/datastores
 dist/var/lib/one/remotes/etc/*                /var/lib/one/remotes/etc/
 dist/var/lib/one/remotes/auth/*               /var/lib/one/remotes/auth/
 dist/var/lib/one/remotes/datastore/*          /var/lib/one/remotes/datastore/

--- a/templates/ubuntu1904/opennebula.postinst
+++ b/templates/ubuntu1904/opennebula.postinst
@@ -11,8 +11,6 @@ if [ "$1" = "configure" ]; then
     chown $ONE_USER:$ONE_GROUP      /var/lib/one
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/vms
     chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/0
-    chown $ONE_USER:$ONE_GROUP      /var/lib/one/datastores/1
     chown -R $ONE_USER:$ONE_GROUP   /var/lib/one/remotes
 
     if [ ! -f $ONEAUTH ]; then

--- a/templates/ubuntu1904/opennebula.postrm
+++ b/templates/ubuntu1904/opennebula.postrm
@@ -2,13 +2,29 @@
 
 set -e
 
-ONEHOME=/var/lib/one
-ONE_GROUP=oneadmin
-ONE_USER=oneadmin
-
-if [ "$1" = "remove" ]; then
+if [ "$1" = 'purge' ]; then
     # Remove logs
-    rm -rf /var/log/one/*
+    rm -rf /var/log/one/oned.log* \
+        /var/log/one/sched.log* \
+        /var/log/one/[[:digit:]]*.log
+
+    # Remove vms directory
+    rm -rf /var/lib/one/vms
+
+    # Remove empty datastore directories
+    for DIR in /var/lib/one/datastores/*   \
+               /var/lib/one/datastores/.*  \
+               /var/lib/one/datastores; do
+        # ignore . and ..
+        BASE_DIR=$(basename "${DIR}")
+        if [ "${BASE_DIR}" = '.' ] || [ "${BASE_DIR}" = '..' ]; then
+            continue
+        fi
+
+        if [ -d "${DIR}" ]; then
+            rmdir --ignore-fail-on-non-empty "${DIR}" 2>/dev/null || :
+        fi
+    done
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Now, only the main `/var/lib/one/datastores` is created by the packages. Initial datastores (0,1) aren't contained in the packages. Cleanup is managed by the postuninstall script and only empty and non-symlinked directories are removed. Incl. `.isofiles`.

Additionally, postuinstall purge has been improved for deb-based systems to drop system logs.