### PR TITLE
Improve Ruby gems packaging

### DIFF
--- a/rubygems/gemfile2pkg
+++ b/rubygems/gemfile2pkg
@@ -181,6 +181,8 @@ def pack_gem(gem, build_dir, fpm_path)
                 '--deb-no-default-config-files',
                 '--deb-ignore-iteration-in-dependencies',
                 '--rpm-ignore-iteration-in-dependencies',
+                '--rpm-autoreq',
+                '--directories', gem[:install_location],
                 '--prefix', gem[:install_location],
                 '--gem-bin-path', gem[:bin_path],
                 '--gem-package-name-prefix', gem[:name_prefix],

--- a/rubygems/gemfile2pkg
+++ b/rubygems/gemfile2pkg
@@ -183,6 +183,8 @@ def pack_gem(gem, build_dir, fpm_path)
                 '--rpm-ignore-iteration-in-dependencies',
                 '--rpm-autoreq',
                 '--directories', gem[:install_location],
+                '--exclude', 'cache',
+                '--exclude', "gems/#{gem[:name]}-#{gem[:version]}/ext",
                 '--prefix', gem[:install_location],
                 '--gem-bin-path', gem[:bin_path],
                 '--gem-package-name-prefix', gem[:name_prefix],

--- a/templates/debian10/control.m4
+++ b/templates/debian10/control.m4
@@ -226,6 +226,9 @@ Package: opennebula-rubygems
 Architecture: all
 Depends: ruby,
          _RUBYGEMS_REQ_
+         libffi6,
+         libsqlite3-0,
+         libmariadb3,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/debian9/control.m4
+++ b/templates/debian9/control.m4
@@ -211,6 +211,9 @@ Package: opennebula-rubygems
 Architecture: all
 Depends: ruby,
          _RUBYGEMS_REQ_
+         libffi6,
+         libsqlite3-0,
+         libmariadbclient18,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1604/control.m4
+++ b/templates/ubuntu1604/control.m4
@@ -234,6 +234,8 @@ Package: opennebula-rubygems
 Architecture: all
 Depends: ruby,
          _RUBYGEMS_REQ_
+         libffi6,
+         libsqlite3-0,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1604/control.m4
+++ b/templates/ubuntu1604/control.m4
@@ -236,6 +236,7 @@ Depends: ruby,
          _RUBYGEMS_REQ_
          libffi6,
          libsqlite3-0,
+         libmysqlclient20,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1804/control.m4
+++ b/templates/ubuntu1804/control.m4
@@ -235,6 +235,8 @@ Package: opennebula-rubygems
 Architecture: all
 Depends: ruby,
          _RUBYGEMS_REQ_
+         libffi6,
+         libsqlite3-0,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1804/control.m4
+++ b/templates/ubuntu1804/control.m4
@@ -237,6 +237,7 @@ Depends: ruby,
          _RUBYGEMS_REQ_
          libffi6,
          libsqlite3-0,
+         libmysqlclient20,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1810/control.m4
+++ b/templates/ubuntu1810/control.m4
@@ -228,6 +228,8 @@ Package: opennebula-rubygems
 Architecture: all
 Depends: ruby,
          _RUBYGEMS_REQ_
+         libffi6,
+         libsqlite3-0,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1810/control.m4
+++ b/templates/ubuntu1810/control.m4
@@ -230,6 +230,7 @@ Depends: ruby,
          _RUBYGEMS_REQ_
          libffi6,
          libsqlite3-0,
+         libmysqlclient20,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1904/control.m4
+++ b/templates/ubuntu1904/control.m4
@@ -228,6 +228,8 @@ Package: opennebula-rubygems
 Architecture: all
 Depends: ruby,
          _RUBYGEMS_REQ_
+         libffi6,
+         libsqlite3-0,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies

--- a/templates/ubuntu1904/control.m4
+++ b/templates/ubuntu1904/control.m4
@@ -230,6 +230,7 @@ Depends: ruby,
          _RUBYGEMS_REQ_
          libffi6,
          libsqlite3-0,
+         libmysqlclient20,
          ${misc:Depends}
 Conflicts: opennebula (<< ${source:Version})
 Description: Metapackage to install all Ruby gem dependencies


### PR DESCRIPTION
- fixes #96, directories are now managed by packager so empty directories are not left on uninstall
- excludes cache and ext directories from packages and reduces packages size from 32MB to 10MB
- enables automatic RPM dependencies in gems with libraries
- set manual DEB dependencies on `opennebula-rubygems`