### PR TITLE
Update LXD deps for debian10

### DIFF
--- a/templates/debian10/control.m4
+++ b/templates/debian10/control.m4
@@ -184,7 +184,8 @@ Depends: opennebula-node,
          libvncserver1,
          e2fsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd, xfsprogs
+Suggests: rbd-nbd,
+          xfsprogs
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap

--- a/templates/debian10/control.m4
+++ b/templates/debian10/control.m4
@@ -182,10 +182,10 @@ Architecture: any
 Depends: opennebula-node,
          kpartx,
          libvncserver1,
-         e2fsprogs
+         e2fsprogs,
+         xfsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd,
-          xfsprogs
+Suggests: rbd-nbd
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap

--- a/templates/debian10/control.m4
+++ b/templates/debian10/control.m4
@@ -181,9 +181,10 @@ Package: opennebula-node-lxd
 Architecture: any
 Depends: opennebula-node,
          kpartx,
-         libvncserver1
+         libvncserver1,
+         e2fsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd
+Suggests: rbd-nbd, xfsprogs
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap

--- a/templates/ubuntu1604/control.m4
+++ b/templates/ubuntu1604/control.m4
@@ -193,9 +193,9 @@ Depends: opennebula-node,
          kpartx,
          libvncserver1,
          e2fsprogs,
+         xfsprogs,
          lxd (>= 3.0.0) | opennebula-lxd-snap (= ${source:Version})
-Suggests: rbd-nbd,
-          xfsprogs
+Suggests: rbd-nbd
 Replaces: lxd (<< 3.0.0),
           lxd-client (<< 3.0.0)
 Conflicts: lxd (<< 3.0.0),

--- a/templates/ubuntu1604/control.m4
+++ b/templates/ubuntu1604/control.m4
@@ -192,8 +192,10 @@ Architecture: any
 Depends: opennebula-node,
          kpartx,
          libvncserver1,
+         e2fsprogs,
          lxd (>= 3.0.0) | opennebula-lxd-snap (= ${source:Version})
-Suggests: rbd-nbd
+Suggests: rbd-nbd,
+          xfsprogs
 Replaces: lxd (<< 3.0.0),
           lxd-client (<< 3.0.0)
 Conflicts: lxd (<< 3.0.0),

--- a/templates/ubuntu1804/control.m4
+++ b/templates/ubuntu1804/control.m4
@@ -193,8 +193,10 @@ Architecture: any
 Depends: opennebula-node,
          kpartx,
          libvncserver1,
+         e2fsprogs
          lxd (>= 3.0.0) | opennebula-lxd-snap (= ${source:Version})
-Suggests: rbd-nbd
+Suggests: rbd-nbd,
+          xfsprogs
 Replaces: lxd (<< 3.0.0),
           lxd-client (<< 3.0.0)
 Conflicts: lxd (<< 3.0.0),

--- a/templates/ubuntu1804/control.m4
+++ b/templates/ubuntu1804/control.m4
@@ -193,10 +193,10 @@ Architecture: any
 Depends: opennebula-node,
          kpartx,
          libvncserver1,
-         e2fsprogs
+         e2fsprogs,
+         xfsprogs
          lxd (>= 3.0.0) | opennebula-lxd-snap (= ${source:Version})
-Suggests: rbd-nbd,
-          xfsprogs
+Suggests: rbd-nbd
 Replaces: lxd (<< 3.0.0),
           lxd-client (<< 3.0.0)
 Conflicts: lxd (<< 3.0.0),

--- a/templates/ubuntu1810/control.m4
+++ b/templates/ubuntu1810/control.m4
@@ -184,10 +184,10 @@ Architecture: any
 Depends: opennebula-node,
          kpartx,
          libvncserver1,
-         e2fsprogs
+         e2fsprogs,
+         xfsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd,
-          xfsprogs
+Suggests: rbd-nbd
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap

--- a/templates/ubuntu1810/control.m4
+++ b/templates/ubuntu1810/control.m4
@@ -183,9 +183,11 @@ Package: opennebula-node-lxd
 Architecture: any
 Depends: opennebula-node,
          kpartx,
-         libvncserver1
+         libvncserver1,
+         e2fsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd
+Suggests: rbd-nbd,
+          xfsprogs
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap

--- a/templates/ubuntu1904/control.m4
+++ b/templates/ubuntu1904/control.m4
@@ -184,10 +184,10 @@ Architecture: any
 Depends: opennebula-node,
          kpartx,
          libvncserver1,
-         e2fsprogs
+         e2fsprogs,
+         xfsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd,
-          xfsprogs
+Suggests: rbd-nbd
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap

--- a/templates/ubuntu1904/control.m4
+++ b/templates/ubuntu1904/control.m4
@@ -183,9 +183,11 @@ Package: opennebula-node-lxd
 Architecture: any
 Depends: opennebula-node,
          kpartx,
-         libvncserver1
+         libvncserver1,
+         e2fsprogs
 Pre-Depends: snapd
-Suggests: rbd-nbd
+Suggests: rbd-nbd,
+          xfsprogs
 Replaces: lxd,
           lxd-client,
           opennebula-lxd-snap


### PR DESCRIPTION
`xfsprogs` ins't installed by default in debian 10, unlike ubuntu >= 1604. The dependency has been stated as optional in all of the distros control files and `e2fsprogs` has been marked as required.

Merge with https://github.com/OpenNebula/infra/pull/314