### PR TITLE
B OpenNebula/packages#115: zeromq3 support for CentOS 8

### DIFF
--- a/templates/centos8/centos8.spec.m4
+++ b/templates/centos8/centos8.spec.m4
@@ -162,9 +162,8 @@ Requires: iputils
 # zeromqX-devel:
 # Devel package brings libzmq.so symlink required by ffi-rzmq-core gem
 %if 0%{?rhel} == 8
-# TODO: fix when zeromq is available on EPEL 8
-# Requires: zeromq
-# Requires: libzmq.so.3 OR libzmq.so.5
+Requires: zeromq3
+Requires: zeromq3-devel
 Requires: pkgconfig(libzmq) >= 3.2
 %endif
 %if 0%{?rhel} == 7


### PR DESCRIPTION
CentOS 8 install_gems  dependency issue. 

Issue: 

> Error: 
>  Problem: problem with installed package zeromq3-devel-3.2.5-3.el8.x86_64
>   - package zeromq3-devel-3.2.5-3.el8.x86_64 conflicts with zeromq-devel(x86-64) provided by zeromq-devel-2.2.0-4.el8.x86_64

CentOS/ RHEL 8 is using zeromq3 , zeromq3-devel by default. 